### PR TITLE
Avoid math.rand lock contention

### DIFF
--- a/election2012.go
+++ b/election2012.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"log"
 	"math"
+	"math/rand"
 	"os"
 	"runtime"
 	"strings"
@@ -110,10 +111,10 @@ func loadStateData(state string, polls []Poll) (prob StateProbability) {
 }
 
 // for each state, flip a coin
-func simulateObamaVotes(states []StateProbability) int {
+func simulateObamaVotes(states []StateProbability, r *rand.Rand) int {
 	votes := 0
 	for _, state := range states {
-		votes += state.simulateElection()
+		votes += state.simulateElection(r)
 	}
 	return votes
 }
@@ -156,8 +157,9 @@ type Result struct {
 
 func doSome(n int, probs []StateProbability, c chan Result) {
 	var voteSum, winSum int
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < n; i++ {
-		votes := simulateObamaVotes(probs)
+		votes := simulateObamaVotes(probs, r)
 		if votes >= 270 {
 			winSum++
 		}

--- a/state.go
+++ b/state.go
@@ -41,9 +41,9 @@ func (s *StateProbability) update(oPerc, rPerc, pollSize int) {
 	s.ObamaProbability = prOverX(0.50, s.obamaPerc, s.σ)
 }
 
-func (s *StateProbability) simulateElection() int {
+func (s *StateProbability) simulateElection(r *rand.Rand) int {
 	if s.N != 0 {
-		if rand.Float64() < s.ObamaProbability {
+		if r.Float64() < s.ObamaProbability {
 			return college[s.state].votes
 		}
 	} else {


### PR DESCRIPTION
When running with multiple threads most of the time is spent in
math.rand waiting for the lock on globalRand. To avoid this use a
separate Rand for each goroutine. Seed from current time.
